### PR TITLE
added support for "background" scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ where ```wlan0``` is the device you'd like to use.
    * 'Arrow key Left' - Tune one channel up (only in 'background' mode)
    * 'Arrow key Right' - Tune one channel up (only in 'background' mode)
  * 'd' - Toggle dumping binary data with timestamp in a file
+ * 'u' - Toggle UI processing
  * 'q' - Quit the program

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ where ```wlan0``` is the device you'd like to use.
  * 'b' - Switch scanner to 'background' mode. Hardware will deliver as much samples as possible
    * 'Arrow key Left' - Tune one channel up (only in 'background' mode)
    * 'Arrow key Right' - Tune one channel up (only in 'background' mode)
+   * 'Arrow key Up' - Increase the number of samples hold for visualization
+   * 'Arrow key Down' - Decrease the number of samples hold for visualization
  * 'm' - Toggle between HT20 [default] and HT40 mode
  * 'd' - Toggle dumping binary data with timestamp in a file
  * 'u' - Toggle UI processing
@@ -39,4 +41,5 @@ where ```wlan0``` is the device you'd like to use.
 
 ## Open issues
 
+ * HT40 decoder seems to produce crap
  * Many features of this software are not tested on 5GHz / ath10k due lack of appropriate hardware

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This is a simple spectrum visualizer based on the ath9k spectral scan feature.
+This is a simple spectrum visualizer and dumper based on the [ath9k spectral scan](https://wireless.wiki.kernel.org/en/users/drivers/ath9k/spectral_scan) feature.
 If you have a Qualcomm/Atheros Wifi device on Linux, and have built the
 driver with debugfs support, you can use this program to see the RF spectrum
 in something resembling real-time.
@@ -9,23 +9,24 @@ in something resembling real-time.
 
 ## Prerequisites
 
- * a device that supports the spectral scan feature (ath9k and ath9k\_htc
+ * one or more Wifi devices that supports the spectral scan feature (only ath9k and ath9k\_htc
    drivers tested at this point)
  * above drivers compiled with debugfs enabled
  * the iw utility installed
 
 ## Usage
 
-As root, run:
+On Ubuntu, run:
 ```
-# ./speccy.py wlan0
+$ sudo python speccy.py wlan0 wlan1 ...
 ```
-where ```wlan0``` is the device you'd like to use.
+where ```wlanN``` are the devices you'd like to use. Up to four devices are supported.
 
 ## Key bindings
 
  * 'l' - Toggle line graph
  * 's' - Toggle scatter plot
+ * '1', '2', '3', '4' - Switch control to device number n. Default is 1
  * 'c' - Switch scanner to 'chanscan' mode [default]. Hardware tunes to all WiFi channels and deliver a certain number of samples per channel. Default is 8
    * 'Arrow key Up' - Double the number of samples (up to 255)
    * 'Arrow key Down' - Divide the number of samples by two (down to 1)
@@ -42,4 +43,4 @@ where ```wlan0``` is the device you'd like to use.
 ## Open issues
 
  * HT40 decoder seems to produce crap
- * Many features of this software are not tested on 5GHz / ath10k due lack of appropriate hardware
+ * This software is not tested on 5GHz / ath10k due lack of appropriate hardware

--- a/README.md
+++ b/README.md
@@ -26,5 +26,8 @@ where ```wlan0``` is the device you'd like to use.
 
  * 'l' - Toggle line graph
  * 's' - Toggle scatter plot
+ * 'c' - Switch scanner to 'chanscan' mode
+ * 'b' - Switch scanner to 'background' mode
+   * 'Arrow key Left' - Tune one channel up (only in 'background' mode)
+   * 'Arrow key Right' - Tune one channel up (only in 'background' mode)
  * 'q' - Quit the program
-

--- a/README.md
+++ b/README.md
@@ -32,4 +32,5 @@ where ```wlan0``` is the device you'd like to use.
  * 'b' - Switch scanner to 'background' mode. Hardware will deliver as much samples as possible
    * 'Arrow key Left' - Tune one channel up (only in 'background' mode)
    * 'Arrow key Right' - Tune one channel up (only in 'background' mode)
+ * 'd' - Toggle dumping binary data with timestamp in a file
  * 'q' - Quit the program

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ where ```wlan0``` is the device you'd like to use.
 
  * 'l' - Toggle line graph
  * 's' - Toggle scatter plot
- * 'c' - Switch scanner to 'chanscan' mode
- * 'b' - Switch scanner to 'background' mode
+ * 'c' - Switch scanner to 'chanscan' mode [Default]. Hardware tunes to all WiFi channels and deliver a certain number of samples per channel. Default is 8
+   * 'Arrow key Up' - Double the number of samples (up to 255)
+   * 'Arrow key Down' - Divide the number of samples by two (down to 1)
+ * 'b' - Switch scanner to 'background' mode. Hardware will deliver as much samples as possible
    * 'Arrow key Left' - Tune one channel up (only in 'background' mode)
    * 'Arrow key Right' - Tune one channel up (only in 'background' mode)
  * 'q' - Quit the program

--- a/README.md
+++ b/README.md
@@ -26,12 +26,17 @@ where ```wlan0``` is the device you'd like to use.
 
  * 'l' - Toggle line graph
  * 's' - Toggle scatter plot
- * 'c' - Switch scanner to 'chanscan' mode [Default]. Hardware tunes to all WiFi channels and deliver a certain number of samples per channel. Default is 8
+ * 'c' - Switch scanner to 'chanscan' mode [default]. Hardware tunes to all WiFi channels and deliver a certain number of samples per channel. Default is 8
    * 'Arrow key Up' - Double the number of samples (up to 255)
    * 'Arrow key Down' - Divide the number of samples by two (down to 1)
  * 'b' - Switch scanner to 'background' mode. Hardware will deliver as much samples as possible
    * 'Arrow key Left' - Tune one channel up (only in 'background' mode)
    * 'Arrow key Right' - Tune one channel up (only in 'background' mode)
+ * 'm' - Toggle between HT20 [default] and HT40 mode
  * 'd' - Toggle dumping binary data with timestamp in a file
  * 'u' - Toggle UI processing
  * 'q' - Quit the program
+
+## Open issues
+
+ * Many features of this software are not tested on 5GHz / ath10k due lack of appropriate hardware

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,95 @@
+from spectrum_file import SpectrumFileReader
+from scanner import Scanner
+import sys
+import Queue
+from datetime import datetime, timedelta
+import time
+
+class AthBenchmark(object):
+
+    def __init__(self, iface):
+        self.scanner = Scanner(iface)
+        fn = '%s/spectral_scan0' % self.scanner.get_debugfs_dir()
+        self.file_reader = SpectrumFileReader(fn)
+        self.interface = iface
+
+    def get_samples(self, duration):
+        sps = 0
+        end = datetime.now() + timedelta(seconds=duration)
+        while datetime.now() < end:
+            try:
+                ts, samples = self.file_reader.sample_queue.get(timeout=0.1)
+            except Queue.Empty:
+                continue
+            sps += len(samples) / (17 + 56)  # (header + payload in HT20)
+        print "total: %d sps" % sps
+        sps /= float(duration)
+        return sps
+
+    # count samples in chanscan
+    def benchmark_chanscan(self, duration=5, samplecount=8):
+        print "\nrun benchmark chanscan with samplecount=%d, duration=%d " % (samplecount, duration)
+        self.scanner.cmd_set_samplecount(samplecount)
+        self.scanner.mode_chanscan()
+        self.scanner.start()
+        sps = self.get_samples(duration=duration)
+        self.scanner.stop()
+        self.file_reader.flush()
+        print "%.2f sps, chanscan" % sps
+        return sps
+
+    # count samples in bg mode (w/o) load
+    def benchmark_background(self, duration=5):
+        print "\nrun benchmark background with duration=%d " % duration
+        self.scanner.mode_noninvasive_background()
+        self.scanner.dev_add_monitor()
+        self.scanner.start()
+        sps = self.get_samples(duration=duration)
+        self.scanner.stop()
+        self.file_reader.flush()
+        print "%.2f sps, background scan " % sps
+        return sps
+
+    def benchmark_manual(self, samplecount=127):
+        print "\nrun benchmark manual with samplecount=%d " % samplecount
+        self.scanner.mode_manual()
+        self.scanner.cmd_manual()
+        self.scanner.cmd_set_samplecount(samplecount)
+        self.scanner.dev_add_monitor()
+        self.scanner.cmd_trigger()
+        sps = 0
+        reread = 3
+        while reread:
+            try:
+                ts, samples = self.file_reader.sample_queue.get(timeout=0.1)
+                sps += len(samples) / (17 + 56)  # (header + payload in HT20)
+            except Queue.Empty:
+                pass
+            reread -= 1
+        self.scanner.stop()
+        self.file_reader.flush()
+        print "got %d samples in manual mode" % sps
+        return sps
+
+    def main(self):
+        samplecount = [1, 10, 50, 100, 150, 200, 255]
+        for sc in samplecount:
+            sps = self.benchmark_chanscan( duration=5, samplecount=sc)
+            print "sps / samplecount: %.2f" % (sps / sc)
+            time.sleep(0.2)
+
+        self.benchmark_background(duration=5)
+        time.sleep(0.2)
+
+        self.benchmark_manual(samplecount=127)
+        time.sleep(0.2)
+
+        self.cleanup()
+
+    def cleanup(self):
+        # self.scanner.stop()
+        self.file_reader.stop()
+
+
+if __name__ == '__main__':
+    AthBenchmark(sys.argv[1]).main()

--- a/example_offline_analysis.py
+++ b/example_offline_analysis.py
@@ -8,9 +8,11 @@ def process(fn):
     f = open(fn, 'r')
     while True:
         try:
-            ts, sample_data = cPickle.load(f)
-            for tsf, freq, noise, rssi, sdata in SpectrumFileReader.decode(sample_data):
-                print ts, tsf, freq, noise
+            device_id, ts, sample_data = cPickle.load(f)
+            for tsf, freq, noise, rssi, pwrs in SpectrumFileReader.decode(sample_data):
+                print device_id, ts, tsf, freq, noise, rssi
+                for carrier_freq, pwr_level in pwrs.iteritems():
+                    print carrier_freq, pwr_level
         except EOFError:
             break
 

--- a/example_offline_analysis.py
+++ b/example_offline_analysis.py
@@ -1,0 +1,25 @@
+from spectrum_file import SpectrumFileReader
+import cPickle
+import os
+
+
+def process(fn):
+    print "processing '%s':" % fn
+    f = open(fn, 'r')
+    while True:
+        try:
+            ts, sample_data = cPickle.load(f)
+            for tsf, freq, noise, rssi, sdata in SpectrumFileReader.decode(sample_data):
+                print ts, tsf, freq, noise
+        except EOFError:
+            break
+
+
+# open all .bin files and process content
+def main():
+    for fn in os.listdir("./spectral_data"):
+        if fn.endswith(".bin"):
+            process("./spectral_data/"+fn)
+
+if __name__ == '__main__':
+    main()

--- a/scanner.py
+++ b/scanner.py
@@ -34,10 +34,11 @@ class Scanner(object):
                 os.system('%s >/dev/null 2>/dev/null' % cmd)
             time.sleep(.01)
 
-    def __init__(self, interface, freqlist=None):
+    def __init__(self, interface, idx=0, freqlist=None):
         self.interface = interface
         self.phy = ""
-        self.monitor_name = "ssmon0"
+        self.idx = idx
+        self.monitor_name = "ssmon%d" % self.idx  # just a arbitrary, but unique id
         self.monitor_added = False
         self.freqlist = freqlist
         self.debugfs_dir = self._find_debugfs_dir()
@@ -53,6 +54,7 @@ class Scanner(object):
         self.mode = Value('i', -1)  # -1 = undef, 1 = 'chanscan', 2 = 'background scan', 3 = 'noninvasive bg scan'
         self.channel_mode = "HT20"
         self.process = None
+        self.file_reader = None
         self.noninvasive = False
 
     def hw_setup_chanscan(self):

--- a/scanner.py
+++ b/scanner.py
@@ -50,7 +50,7 @@ class Scanner(object):
         self.sample_count_file = '%s/spectral_count' % self.debugfs_dir
         self.cur_chan = 6
         self.sample_count = 8
-        self.mode = Value('i', 1)  # mode 1 = 'chanscan', mode 2 = 'background scan'
+        self.mode = Value('i', -1)  # -1 = undef, 1 = 'chanscan', 2 = 'background scan', 3 = 'noninvasive bg scan'
         self.channel_mode = "HT20"
         self.process = None
         self.noninvasive = False
@@ -204,9 +204,9 @@ class Scanner(object):
             self.monitor_added = False
 
     def start(self):
-        self.hw_setup_chanscan()  # start in chanscan mode
-        self.process = Process(target=self._scan, args=())
-        self.process.start()
+        if self.process is None:
+            self.process = Process(target=self._scan, args=())
+            self.process.start()
 
     def stop(self):
         if self.channel_mode != "HT20":
@@ -218,6 +218,7 @@ class Scanner(object):
             self.process.terminate()
             self.process.join()
             self.process = None
+        self.mode.value = -1
 
     def get_debugfs_dir(self):
         return self.debugfs_dir

--- a/scanner.py
+++ b/scanner.py
@@ -119,6 +119,11 @@ class Scanner(object):
         f.write("chanscan")
         f.close()
 
+    def cmd_disable(self):
+        f = open(self.ctl_file, 'w')
+        f.write("disable")
+        f.close()
+
     def cmd_setchannel(self, ch):
         os.system("iw dev %s set channel %d" % (self.interface, ch))
 
@@ -127,6 +132,7 @@ class Scanner(object):
         self.process.start()
 
     def stop(self):
+        self.cmd_disable()
         self.process.terminate()
         self.process.join()
 

--- a/scanner.py
+++ b/scanner.py
@@ -41,12 +41,12 @@ class Scanner(object):
         self.interface = interface
         self.freqlist = freqlist
         self.debugfs_dir = self._find_debugfs_dir()
-        self.is_ath10k = self.debugfs_dir.endswith("ath10k")
-        self.ctl_file = '%s/spectral_scan_ctl' % self.debugfs_dir
         if not self.debugfs_dir:
             raise Exception, \
                   'Unable to access spectral_scan_ctl file for interface %s' % interface
 
+        self.is_ath10k = self.debugfs_dir.endswith("ath10k")
+        self.ctl_file = '%s/spectral_scan_ctl' % self.debugfs_dir
         self.process = Process(target=self._scan, args=())
 
     def cmd_trigger(self):

--- a/scanner.py
+++ b/scanner.py
@@ -21,21 +21,15 @@ class Scanner(object):
         return None
 
     def _start_collection(self):
-        fn = '%s/spectral_scan_ctl' % self.debugfs_dir
-        f = open(fn, 'w')
         if self.is_ath10k:
-            f.write("background")
+            self.cmd_background()
         else:
-            f.write("chanscan")
-        f.close()
+            self.cmd_chanscan()
 
     def _scan(self):
         while True:
             if self.is_ath10k:
-                fn = '%s/spectral_scan_ctl' % self.debugfs_dir
-                f = open(fn, 'w')
-                f.write("trigger")
-                f.close()
+                self.cmd_trigger()
 
             cmd = 'iw dev %s scan' % self.interface
             if self.freqlist:
@@ -48,11 +42,32 @@ class Scanner(object):
         self.freqlist = freqlist
         self.debugfs_dir = self._find_debugfs_dir()
         self.is_ath10k = self.debugfs_dir.endswith("ath10k")
+        self.ctl_file = '%s/spectral_scan_ctl' % self.debugfs_dir
         if not self.debugfs_dir:
             raise Exception, \
                   'Unable to access spectral_scan_ctl file for interface %s' % interface
 
         self.process = Process(target=self._scan, args=())
+
+    def cmd_trigger(self):
+        f = open(self.ctl_file, 'w')
+        f.write("trigger")
+        f.close()
+
+    def cmd_background(self):
+        f = open(self.ctl_file, 'w')
+        f.write("background")
+        f.close()
+
+    """def cmd_manual(self):
+        f = open(self.ctl_file, 'w')
+        f.write("manual")
+        f.close()"""
+
+    def cmd_chanscan(self):
+        f = open(self.ctl_file, 'w')
+        f.write("chanscan")
+        f.close()
 
     def start(self):
         self._start_collection()

--- a/speccy.py
+++ b/speccy.py
@@ -39,9 +39,11 @@ class Speccy(object):
 
     def quit(self, *args):
         Gtk.main_quit()
-
-    def cleanup(self, *args):
+        self.cleanup()
+    
+    def cleanup(self):
         self.scanner.stop()
+        self.sf.flush()
 
     def on_key_press(self, w, event):
         key = Gdk.keyval_name(event.keyval)
@@ -70,7 +72,6 @@ class Speccy(object):
         #    self.scanner.cmd_trigger
         else:
             pass  # ignore unknown key
-
 
     def gen_pallete(self):
         # create a 256-color gradient from blue->green->white

--- a/speccy.py
+++ b/speccy.py
@@ -36,7 +36,7 @@ class Speccy(object):
     def __init__(self, ifaces):
         self.color_map = self.gen_pallete()
         self.scanners = []
-        idx = 1
+        idx = 0
         for iface in ifaces:
             scanner = Scanner(iface, idx=idx)
             scanner.mode_chanscan()
@@ -45,7 +45,7 @@ class Speccy(object):
             scanner.file_reader = reader
             self.scanners.append(scanner)
             idx += 1
-        self.dev_idx = 1  # id of currently selected device
+        self.dev_idx = 0  # id of currently selected device
         if not os.path.exists("./spectral_data"):
             os.mkdir("./spectral_data")
         self.dump_to_file = False

--- a/speccy.py
+++ b/speccy.py
@@ -36,6 +36,7 @@ class Speccy(object):
     def __init__(self, iface):
         self.color_map = self.gen_pallete()
         self.scanner = Scanner(iface)
+        self.scanner.mode_chanscan()
         fn = '%s/spectral_scan0' % self.scanner.get_debugfs_dir()
         self.file_reader = SpectrumFileReader(fn)
         self.mode_background = False

--- a/speccy.py
+++ b/speccy.py
@@ -71,9 +71,10 @@ class Speccy(object):
             self.reset_viewport()
             self.scanner.retune_up()
             self.sf.flush()
-        #elif key == 'Up':
-        #    print "debug: write 'trigger'"
-        #    self.scanner.cmd_trigger
+        elif key == 'Up':
+            self.scanner.cmd_samplecount_up()
+        elif key == 'Down':
+            self.scanner.cmd_samplecount_down()
         else:
             pass  # ignore unknown key
 

--- a/speccy.py
+++ b/speccy.py
@@ -107,6 +107,11 @@ class Speccy(object):
                 self.dump_to_file = True
         elif key == 'u':
             self.ui_update = not self.ui_update
+        elif key == 'm':
+            self.reset_viewport()
+            self.scanner.cmd_toggle_HTMode()
+            self.file_reader.flush()
+
         else:
             pass  # ignore unknown key
 

--- a/speccy.py
+++ b/speccy.py
@@ -40,7 +40,7 @@ class Speccy(object):
     def quit(self, *args):
         Gtk.main_quit()
         self.cleanup()
-    
+
     def cleanup(self):
         self.scanner.stop()
         self.sf.flush()
@@ -57,16 +57,20 @@ class Speccy(object):
             self.scanner.mode_background()
             self.mode_background = True
             self.reset_viewport()
+            self.sf.flush()
         elif key == 'c':
             self.scanner.mode_chanscan()
             self.mode_background = False
             self.reset_viewport()
+            self.sf.flush()
         elif key == 'Left':
             self.reset_viewport()
             self.scanner.retune_down()
+            self.sf.flush()
         elif key == 'Right':
             self.reset_viewport()
             self.scanner.retune_up()
+            self.sf.flush()
         #elif key == 'Up':
         #    print "debug: write 'trigger'"
         #    self.scanner.cmd_trigger

--- a/speccy.py
+++ b/speccy.py
@@ -96,7 +96,11 @@ class Speccy(object):
                 self.dump_file.close()
                 print "dump to file finished"
             else:
-                fn = "./spectral_data/%s.bin" % datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+                if self.mode_background:
+                    mode = "bg"
+                else:
+                    mode = "ch"
+                fn = "./spectral_data/%s_%s.bin" % (datetime.now().strftime("%Y-%m-%d_%H-%M-%S"), mode)
                 print "start dumping to %s" % fn
                 self.dump_file = open(fn, 'w')
                 self.dump_to_file = True

--- a/speccy.py
+++ b/speccy.py
@@ -43,6 +43,7 @@ class Speccy(object):
             os.mkdir("./spectral_data")
         self.dump_to_file = False
         self.dump_file = None
+        self.ui_update = True
 
     def quit(self, *args):
         Gtk.main_quit()
@@ -104,6 +105,8 @@ class Speccy(object):
                 print "start dumping to %s" % fn
                 self.dump_file = open(fn, 'w')
                 self.dump_to_file = True
+        elif key == 'u':
+            self.ui_update = not self.ui_update
         else:
             pass  # ignore unknown key
 
@@ -210,6 +213,9 @@ class Speccy(object):
 
         if self.dump_to_file:
             cPickle.dump((ts, xydata), self.dump_file)
+
+        if not self.ui_update:
+            return True
 
         for tsf, freq, noise, rssi, sdata in SpectrumFileReader.decode(xydata):
             if freq < self.last_x or self.mode_background:

--- a/speccy.py
+++ b/speccy.py
@@ -277,7 +277,7 @@ class Speccy(object):
                     cr.set_source_rgba(color[0], color[1], color[2], .8)
                     cr.fill()
 
-        if self.show_envelope:
+        if self.show_envelope and len(self.max_per_freq.keys()) > 0:
             freqs = sorted(self.max_per_freq.keys())
             pow_data = [self.max_per_freq[f] for f in freqs]
             pow_data = self.smooth_data(pow_data, 4)

--- a/speccy.py
+++ b/speccy.py
@@ -71,16 +71,24 @@ class Speccy(object):
             self.reset_viewport()
             self.file_reader.flush()
         elif key == 'Left':
+            if not self.mode_background:
+                return
             self.reset_viewport()
             self.scanner.retune_down()
             self.file_reader.flush()
         elif key == 'Right':
+            if not self.mode_background:
+                return
             self.reset_viewport()
             self.scanner.retune_up()
             self.file_reader.flush()
         elif key == 'Up':
+            if self.mode_background:
+                return
             self.scanner.cmd_samplecount_up()
         elif key == 'Down':
+            if self.mode_background:
+                return
             self.scanner.cmd_samplecount_down()
         elif key == 'd':
             if self.dump_to_file:

--- a/spectrum_file.py
+++ b/spectrum_file.py
@@ -1,43 +1,70 @@
 #!/usr/bin/python
 import struct
+import time
+import threading
+from Queue import Queue
+from datetime import datetime
 
-def open(path):
-    return SpectrumFile(path)
 
-class SpectrumFile(object):
+class SpectrumFileReader(object):
 
     def __init__(self, path):
         self.fp = file(path)
-        self.buf = ""
-
-    def flush(self):
-        self.buf = ""
-        self.fp.read()
-
-    def read(self):
-        """
-        Return all of the available samples, as a set of (tsf, freq, signal)
-        pairs.  For partial reads, samples are buffered until available.
-        """
         if not self.fp:
-            raise ValueError, 'No open file'
+            print "Cant open file '%s'" % path
+            raise
+        self.sample_queue = Queue()
+        self.reader_thread = threading.Thread(target=self.read_samples_thread, args=())
+        self.reader_thread_stop = False
+        self.reader_thread_pause = False
+        self.reader_thread.start()
 
-        data = self.buf + self.fp.read()
+    def stop(self):
+        self.reader_thread_stop = True
+        self.reader_thread.join()
+        self.flush()
 
-        vals = []
+    def flush(self):  # flush queue and empty file / debugfs buffer (dirty)
+        self.reader_thread_pause = True
+        while not self.sample_queue.empty():
+            self.sample_queue.get()
+        self.fp.read()
+        self.reader_thread_pause = False
+
+    def read_samples_thread(self):
+        while not self.reader_thread_stop:
+            if self.reader_thread_pause:
+                continue
+            data = self.fp.read()
+            if not data:
+                time.sleep(.05)
+                continue
+            self.sample_queue.put(data)
+
+
+    hdrsize = 3
+    type1_pktsize = 17 + 56
+    type2_pktsize = 24 + 128
+    type3_pktsize = 26 + 64
+
+    @staticmethod
+    def decode(data):
         pos = 0
-
-        hdrsize = 3
-        while pos < len(data) - hdrsize + 1:
+        while pos < len(data) - SpectrumFileReader.hdrsize + 1:
 
             (stype, slen) = struct.unpack_from(">BH", data, pos)
 
+            if not ((stype == 1 and slen == SpectrumFileReader.type1_pktsize) or
+                    (stype == 2 and slen == SpectrumFileReader.type2_pktsize) or
+                    (stype == 3 and slen == SpectrumFileReader.type3_pktsize)):
+                break  # header malformed, discard data. This event is very unlikely (once in ~3h)
+                # On the other hand, if we buffer the sample in a primitive way, we consume to much cpu
+                # for only one or too "rescued" samples every 2-3 hours
+
             # 20 MHz
             if stype == 1:
-                pktsize = 17 + 56
-                if pos >= len(data) - hdrsize - pktsize + 1:
+                if pos >= len(data) - SpectrumFileReader.hdrsize - SpectrumFileReader.type1_pktsize + 1:
                     break
-
                 pos += 3
                 (max_exp, freq, rssi, noise, max_mag, max_index, hweight, tsf) = \
                     struct.unpack_from(">BHbbHBBQ", data, pos)
@@ -45,14 +72,12 @@ class SpectrumFile(object):
 
                 sdata = struct.unpack_from("56B", data, pos)
                 pos += 56
-                vals.append((tsf, freq, noise, rssi, sdata))
+                yield (tsf, freq, noise, rssi, sdata)
 
             # 40 MHz
             elif stype == 2:
-                pktsize = 24 + 128
-                if pos >= len(data) - hdrsize - pktsize + 1:
+                if pos >= len(data) - SpectrumFileReader.hdrsize - SpectrumFileReader.type2_pktsize + 1:
                     break
-
                 pos += 3
                 (chantype, freq, rssi_l, rssi_u, tsf, noise_l, noise_u,
                  max_mag_l, max_mag_u, max_index_l, max_index_u,
@@ -64,13 +89,11 @@ class SpectrumFile(object):
                 pos += 128
 
                 # FIXME send as two halves?
-                vals.append((tsf, freq, noise_l, rssi_l, sdata))
+                yield (tsf, freq, noise_l, rssi_l, sdata)
 
             # ath10k
             elif stype == 3:
-
-                pktsize = 26 + 64
-                if pos >= len(data) - hdrsize - pktsize + 1:
+                if pos >= len(data) - SpectrumFileReader.hdrsize - SpectrumFileReader.type3_pktsize + 1:
                     break
                 pos += 3
                 (chanwidth, freq1, freq2, noise, max_mag, gain_db,
@@ -81,12 +104,4 @@ class SpectrumFile(object):
 
                 sdata = struct.unpack_from("64B", data, pos)
                 pos += 64
-                vals.append((tsf, freq1, noise, rssi, sdata))
-
-            else:
-                print "Unknown sample type %d" % stype
-                pos += slen
-
-
-        self.buf = data[pos:]
-        return vals
+                yield (tsf, freq1, noise, rssi, sdata)

--- a/spectrum_file.py
+++ b/spectrum_file.py
@@ -91,21 +91,23 @@ class SpectrumFileReader(object):
                 sumsq_sample = 0
                 samples = []
                 for raw_sample in sdata:
-                    sample = raw_sample << max_exp
-                    sumsq_sample += sample*sample
-                    if sample == 0:
+                    if raw_sample == 0:
                         sample = 1
+                    else:
+                        sample = raw_sample << max_exp
+                    sumsq_sample += sample*sample
                     samples.append(sample)
 
                 if sumsq_sample == 0:
                     sumsq_sample = 1
+                sumsq_sample = 10 * math.log10(sumsq_sample)
 
                 sc_total = 56  # HT20: 56 OFDM subcarrier, HT40: 128
                 first_sc = freq - SpectrumFileReader.sc_wide * (sc_total/2 + 0.5)
                 pwr = {}
                 for i, sample in enumerate(samples):
                     subcarrier_freq = first_sc + i*SpectrumFileReader.sc_wide
-                    sigval = noise + rssi + 20 * math.log10(sample) - 10 * math.log10(sumsq_sample)
+                    sigval = noise + rssi + 20 * math.log10(sample) - sumsq_sample
                     pwr[subcarrier_freq] = sigval
 
                 yield (tsf, freq, noise, rssi, pwr)

--- a/spectrum_file.py
+++ b/spectrum_file.py
@@ -10,6 +10,10 @@ class SpectrumFile(object):
         self.fp = file(path)
         self.buf = ""
 
+    def flush(self):
+        self.buf = ""
+        self.fp.read()
+
     def read(self):
         """
         Return all of the available samples, as a set of (tsf, freq, signal)

--- a/spectrum_file.py
+++ b/spectrum_file.py
@@ -2,6 +2,7 @@
 import struct
 import time
 import threading
+import math
 from Queue import Queue
 from datetime import datetime
 
@@ -42,14 +43,24 @@ class SpectrumFileReader(object):
                 continue
             self.sample_queue.put((ts, data))
 
-
+    # spectral scan packet format constants
     hdrsize = 3
     type1_pktsize = 17 + 56
     type2_pktsize = 24 + 128
     type3_pktsize = 26 + 64
 
+    # ieee 802.11 constants
+    sc_wide = 0.3125 # in MHz
+
     @staticmethod
     def decode(data):
+        """
+        For information about the decoding of spectral samples see:
+        https://wireless.wiki.kernel.org/en/users/drivers/ath9k/spectral_scan
+        https://github.com/erikarn/ath_radar_stuff/tree/master/lib
+        and your ath9k implementation in e.g.
+        /drivers/net/wireless/ath/ath9k/common-spectral.c
+        """
         pos = 0
         while pos < len(data) - SpectrumFileReader.hdrsize + 1:
 
@@ -73,7 +84,31 @@ class SpectrumFileReader(object):
 
                 sdata = struct.unpack_from("56B", data, pos)
                 pos += 56
-                yield (tsf, freq, noise, rssi, sdata)
+
+                # unscale bins + create binsum
+                sumsq_sample = 0
+                samples = []
+                for raw_sample in sdata:
+                    sample = raw_sample << max_exp
+                    sumsq_sample += sample*sample
+                    if sample == 0:
+                        sample = 1
+                    samples.append(sample)
+
+                if sumsq_sample == 0:
+                    sumsq_sample = 1
+
+                # calculate power in dBm
+                sc_total = 56  # HT20: 56 ODFM subcarrier, HT40: 128
+                first_sc = freq - SpectrumFileReader.sc_wide * (sc_total/2 + 0.5)
+                pwr = {}
+                for i, sample in enumerate(samples):
+                    subcarrier_freq = first_sc + i*SpectrumFileReader.sc_wide
+                    sigval = noise + rssi + 20 * math.log10(sample) - 10 * math.log10(sumsq_sample)
+                    pwr[subcarrier_freq] = sigval
+
+                yield (tsf, freq, noise, rssi, pwr)
+
 
             # 40 MHz
             elif stype == 2:

--- a/spectrum_file.py
+++ b/spectrum_file.py
@@ -35,11 +35,12 @@ class SpectrumFileReader(object):
         while not self.reader_thread_stop:
             if self.reader_thread_pause:
                 continue
+            ts = datetime.now()
             data = self.fp.read()
             if not data:
                 time.sleep(.05)
                 continue
-            self.sample_queue.put(data)
+            self.sample_queue.put((ts, data))
 
 
     hdrsize = 3

--- a/spectrum_file.py
+++ b/spectrum_file.py
@@ -66,7 +66,7 @@ class SpectrumFileReader(object):
             if stype == 1:
                 if pos >= len(data) - SpectrumFileReader.hdrsize - SpectrumFileReader.type1_pktsize + 1:
                     break
-                pos += 3
+                pos += SpectrumFileReader.hdrsize
                 (max_exp, freq, rssi, noise, max_mag, max_index, hweight, tsf) = \
                     struct.unpack_from(">BHbbHBBQ", data, pos)
                 pos += 17
@@ -79,7 +79,7 @@ class SpectrumFileReader(object):
             elif stype == 2:
                 if pos >= len(data) - SpectrumFileReader.hdrsize - SpectrumFileReader.type2_pktsize + 1:
                     break
-                pos += 3
+                pos += SpectrumFileReader.hdrsize
                 (chantype, freq, rssi_l, rssi_u, tsf, noise_l, noise_u,
                  max_mag_l, max_mag_u, max_index_l, max_index_u,
                  hweight_l, hweight_u, max_exp) = \
@@ -96,7 +96,7 @@ class SpectrumFileReader(object):
             elif stype == 3:
                 if pos >= len(data) - SpectrumFileReader.hdrsize - SpectrumFileReader.type3_pktsize + 1:
                     break
-                pos += 3
+                pos += SpectrumFileReader.hdrsize
                 (chanwidth, freq1, freq2, noise, max_mag, gain_db,
                  base_pwr_db, tsf, max_index, rssi, relpwr_db, avgpwr_db,
                  max_exp) = \


### PR DESCRIPTION
Hi Bob,
love your handy tool. I've added support for the 'background' mode of spectral scan where a channel is observed continuously.

Minor changes consist:
- fixed frequency range to match outside US -> maybe this should read out from ``iw reg get`
- minor refactoring

Please note: Due lack of ath10k hardware, **this stuff is only tested on ath9k_htc** :(

BR
Robert
